### PR TITLE
Start multiple instances of houses

### DIFF
--- a/Sim_Harness_GUI/InstanceManager.cs
+++ b/Sim_Harness_GUI/InstanceManager.cs
@@ -170,6 +170,19 @@ public class InstanceManager{
 	}
 
 	/**
+	 * This function will read in the JSON blob and find every house name and return a list of the house names
+	 */
+	private List<string> findHouses()
+	{
+		// TODO: Read in the JSON blob
+		List<string> houseNames = new List<string>();
+		houseNames.Add("house1");
+		houseNames.Add("house2");
+		houseNames.Add("new house");
+		return houseNames;
+	}
+
+	/**
 	 * Attempts to start every single simHouse in the list and returns any that fail to 
 	 * open correctly
 	 */ 
@@ -182,7 +195,7 @@ public class InstanceManager{
 			_houses[i].Start();
 			if(_houses[i].ProcessStarted)
 			{
-				_houses[i].waitForResponse();
+//				_houses[i].waitForResponse();
 			}
 			if(!_houses[i].ProcessStarted || _houses[i].Error)
 			{
@@ -225,7 +238,7 @@ public class InstanceManager{
 		{
 			output += house.ToString() + "\n\n";
 		}
-		return "";
+		return output;
 	}
 
 } //end class


### PR DESCRIPTION
Clayton,
I'm pulling this request because it's easier to see the problems this way. You don't necessary have to merge this. I'm not sure if I'm doing it in the right way so I'd rather not working in your branch directly. 

So the first thing I did was adding findHouses back, which is not in your implementation right now.

In terms of starting multiple houses, it really doesn't require additional work because each sim house object has its own Process called _process. So each time we call _houses[i].Start(), it starts itself. Now the problem is, the second house process somehow stuck in a while loop at _houses[i].waitForResponse(); 

More specifically at: Simhouse.cs (line:71) 
while(_standardOut.EndOfStream && _errorOut.EndOfStream)

I'm not sure what that is actually doing, but if I comment that out, it works fine. In gui output you can see multiple process of house.exe running.
